### PR TITLE
fix: make table responsive and adaptive to width

### DIFF
--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -219,12 +219,12 @@ function Table({ className, style, ...props }: React.ComponentProps<"table">) {
   return (
     <div
       data-slot="table-container"
-      className="w-full min-w-full overflow-x-auto h-full"
+      className="w-full overflow-x-auto h-full"
     >
       <table
         data-slot="table"
         className={cn(
-          "w-full min-w-full text-sm border-collapse table-fixed",
+          "w-full text-sm border-collapse table-auto",
           className
         )}
         style={{ ...style }}
@@ -281,9 +281,10 @@ function TableHead({
       data-slot="table-head"
       className={cn(
         "text-foreground h-12 px-4 py-2 text-left align-middle font-medium border-b",
-        "max-w-[500px] min-w-[120px] truncate", // enforce consistent column sizing
+        "min-w-[120px]",
         className
       )}
+      style={{ maxWidth: "500px", ...props.style }}
       {...props}
     >
       <div className="flex items-center gap-2 w-full min-w-0">
@@ -300,9 +301,10 @@ function TableCell({ className, children, ...props }: React.ComponentProps<"td">
       data-slot="table-cell"
       className={cn(
         "px-4 py-2 align-middle border-b",
-        "max-w-[500px] min-w-[120px] overflow-hidden whitespace-nowrap text-ellipsis",
+        "min-w-[120px] overflow-hidden whitespace-nowrap text-ellipsis",
         className
       )}
+      style={{ maxWidth: "500px", ...props.style }}
       {...props}
     >
       <div className="truncate min-w-0">


### PR DESCRIPTION
Fixes #16

## Summary
Implemented responsive table behavior as requested:
- Table now takes full available width
- Cells have min-width of 120px and max-width of 500px
- Column headers align properly with cells
- Horizontal scroll appears when content overflows

## Changes
- Changed from `table-fixed` to `table-auto` layout
- Removed `min-w-full` to allow natural width sizing
- Moved max-width constraints to inline styles for flexibility
- Preserved horizontal scroll with `overflow-x-auto`

Generated with [Claude Code](https://claude.ai/code)